### PR TITLE
docs: Remove unecessary line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # fake-who
 
-========
-
 An exploration of hiding your user activity from other active users on a Linux system. Of course, only do this on your on hardware.
 
 ## Requirements


### PR DESCRIPTION
The  README markdown file had a line made of equal signs that is not
part of the standard markdown syntax. This has now been removed to make
it easier to read.